### PR TITLE
fix: Fixes schema issue in blindfold_file resource

### DIFF
--- a/internal/provider/blindfold_file_resource.go
+++ b/internal/provider/blindfold_file_resource.go
@@ -43,7 +43,7 @@ func NewBlindfoldFileResource() resource.Resource {
 
 // Implement the Metadata function for Resource interface.
 func (r *blindfoldFileResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_blindfold"
+	resp.TypeName = req.ProviderTypeName + "_blindfold_file"
 }
 
 // Implement the Schema function for Resource interface. Blindfold resources are configured to accept plaintext data,


### PR DESCRIPTION
The schema was mistakenly identifying as 'blindfold' instead of 'blindfold_file'.